### PR TITLE
解决 fstring 过长的问题

### DIFF
--- a/ayugespidertools/scraper/spiders/__init__.py
+++ b/ayugespidertools/scraper/spiders/__init__.py
@@ -228,7 +228,12 @@ class AyuSpider(Spider):
 
             # 如果打开了 mysql_engine_enabled 参数(用于 spiders 中数据入库前去重查询)
             if cls.mysql_engine_enabled:
-                mysql_url = f'mysql+pymysql://{mysql_conf.get("user")}:{mysql_conf.get("password")}@{mysql_conf.get("host")}:{mysql_conf.get("port")}/{mysql_conf.get("database")}?charset={mysql_conf.get("charset")}'
+                mysql_url = (
+                    f'mysql+pymysql://{mysql_conf.get("user")}'
+                    f':{mysql_conf.get("password")}@{mysql_conf.get("host")}'
+                    f':{mysql_conf.get("port")}/{mysql_conf.get("database")}'
+                    f'?charset={mysql_conf.get("charset")}'
+                )
                 spider.mysql_engine = MySqlEngineClass(engine_url=mysql_url).engine
 
         # 2).配置 MongoDB 的相关信息，如果存在 MongoDB 配置，则把 mongodb_conf 添加到 spider 上


### PR DESCRIPTION
解决在配置 `mysql_engine` 时所需的参数 `mysql_url` 在使用 `fstring` 拼接下的长度过长的问题，用于提高可读性和代码规范。